### PR TITLE
bool passed as header replaced by integer

### DIFF
--- a/read_write_data/README.rst
+++ b/read_write_data/README.rst
@@ -36,7 +36,7 @@ of optional parameters, 3 of which are shown here:
 
    import pandas as pd
 
-   df = pd.read_csv('penguin_sector.csv', index_col=0, sep=',', header=True)
+   df = pd.read_csv('penguin_sector.csv', index_col=0, sep=',', header=0)
 
 ----
 


### PR DESCRIPTION
In earlier versions (<0.17) of pandas, if a bool was passed to the header argument of read_csv, read_excel, or read_html it was implicitly converted to an integer. This has been depreciated. A bool input to the header raises a TypeError for pandas version ≥ 0.17.
Release Notes v0.17: https://pandas.pydata.org/pandas-docs/stable/whatsnew/v0.17.0.html#changes-to-bool-passed-as-header-in-parsers
API Reference:  https://pandas.pydata.org/docs/reference/api/pandas.read_csv.html?highlight=read_csv#pandas.read_csv